### PR TITLE
ci: remove shpinx as direct dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m build
-          twine upload dist/*
+          twine upload dist/* --verbose
 
       - name: merge in release
         uses: devmasx/merge-branch@master

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         include:
           - os: macos-latest # macos test
             python-version: "3.10"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
       - pip install --find-links=https://girder.github.io/large_image_wheels --no-cache GDAL
     # patch deprecated and sphinx version to mimic nox build
     post_install:
-      - pip install git+https://github.com/sphinx-doc/sphinx.git
+      - pip install sphinx
     pre_build:
       - sphinx-apidoc --force --module-first --templatedir=docs/source/_templates/apidoc -o docs/source/modules ./sepal_ui
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     # building widgets
     "tomli",
@@ -33,7 +32,6 @@ dependencies = [
     # read local data
     "rioxarray",
     "dask",  # used by rioxarray in the inspector
-    'geopandas==0.13.2; python_version == "3.8"',
     'geopandas>=0.14.0; python_version > "3.8"',
     "matplotlib",
     "jupyter-server-proxy", # required for localtileserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ test = [
     "tomli",
 ]
 doc = [
-    "sphinx @ git+https://github.com/sphinx-doc/sphinx.git",
+    "sphinx",
     "jupyter-sphinx",
     "pydata-sphinx-theme",
     "sphinx-notfound-page",


### PR DESCRIPTION
Aims to close #944 by removing the direct dependency and just installing the latest release.

Let's the tests see if it works.