### PR TITLE
fix: revert to legacy draw control due to errors

### DIFF
--- a/sepal_ui/mapping/draw_control.py
+++ b/sepal_ui/mapping/draw_control.py
@@ -10,7 +10,7 @@ from shapely import geometry as sg
 from sepal_ui import color
 
 
-class DrawControl(ipl.GeomanDrawControl):
+class DrawControl(ipl.DrawControl):
 
     m: Optional[ipl.Map] = None
     "the map on which he drawControl is displayed. It will help control the visibility"


### PR DESCRIPTION
- Due to errors when using this tool, our tests should be more consistent with this tool.